### PR TITLE
Partial Fix for Cypress Touchpad Issues.

### DIFF
--- a/crostouchpad/cyapa.c
+++ b/crostouchpad/cyapa.c
@@ -366,7 +366,7 @@ Status
 NTSTATUS
 OnD0Exit(
 _In_  WDFDEVICE               FxDevice,
-_In_  WDF_POWER_DEVICE_STATE  FxPreviousState
+_In_  WDF_POWER_DEVICE_STATE  FxTargetState
 )
 /*++
 
@@ -377,7 +377,7 @@ This routine destroys objects needed by the driver.
 Arguments:
 
 FxDevice - a handle to the framework device object
-FxPreviousState - previous power state
+FxTargetState - the target power state
 
 Return Value:
 
@@ -385,11 +385,15 @@ Status
 
 --*/
 {
-	UNREFERENCED_PARAMETER(FxPreviousState);
+	UNREFERENCED_PARAMETER(FxTargetState);
 
 	PCYAPA_CONTEXT pDevice = GetDeviceContext(FxDevice);
 
+	if (FxTargetState != 5) {
+
 	cyapa_set_power_mode(pDevice, CMD_POWER_MODE_OFF);
+	
+	}
 
 	WdfTimerStop(pDevice->Timer, TRUE);
 


### PR DESCRIPTION
Since the addition of power management, the Cypress driver sometimes gets stuck on reboot, and the touchpad fails to start. I suspect this is because the driver sometimes can't get the touchpad back on due to touchpad firmware timing issues as discussed previously. Using the fix previously developed to fix rebooting to Linux in the other drivers, this issue can be resolved on Cypress as well.

Some people have also reported the touchpad getting stuck upon waking from sleep/hibernation. I have not been able to reproduce that. Obviously, this fix can't cover sleep/hibernation issues without breaking power management, but it is still a significant partial fix.