### PR TITLE
Better Cypress Fix.

### DIFF
--- a/crostouchpad/cyapa.c
+++ b/crostouchpad/cyapa.c
@@ -348,6 +348,8 @@ Status
 
 	PCYAPA_CONTEXT pDevice = GetDeviceContext(FxDevice);
 	NTSTATUS status = STATUS_SUCCESS;
+	
+	cyapa_set_power_mode(pDevice, CMD_POWER_MODE_FULL);
 
 	WdfTimerStart(pDevice->Timer, WDF_REL_TIMEOUT_IN_MS(10));
 
@@ -389,12 +391,8 @@ Status
 
 	PCYAPA_CONTEXT pDevice = GetDeviceContext(FxDevice);
 
-	if (FxTargetState != 5) {
-
 	cyapa_set_power_mode(pDevice, CMD_POWER_MODE_OFF);
 	
-	}
-
 	WdfTimerStop(pDevice->Timer, TRUE);
 
 	pDevice->ConnectInterrupt = false;


### PR DESCRIPTION
The idea is that the touchpad isn't being woken up sometimes due to delays caused by the touchpad firmware. This extra wakeup should wake it in case the first one didn't.

This fix has totally resolved the issue in my extensive testing and has been confirmed by two users.